### PR TITLE
amesos2: workaround for transpose solves with shylubasker

### DIFF
--- a/packages/amesos2/example/SimpleSolveTranspose.cpp
+++ b/packages/amesos2/example/SimpleSolveTranspose.cpp
@@ -204,6 +204,36 @@ int main(int argc, char *argv[]) {
     solver->numericFactorization();
     solver->solve();
 
+    *fos << "\nAT^-1 * BT Solution :" << std::endl;
+    X->describe(*fos,Teuchos::VERB_EXTREME);
+  }
+
+  {
+    // Solve A \ B then Solve A' \ BT - same solver instance
+    // Create solver interface to Superlu with Amesos2 factory method
+    RCP<Amesos2::Solver<MAT,MV> > solver = Amesos2::create<MAT,MV>("ShyLUBasker", A, X, B);
+
+    Teuchos::ParameterList amesos2_params("Amesos2");
+    amesos2_params.sublist("ShyLUBasker").set("num_threads", 1, "Num threads == 1 by default");
+    solver->setParameters( Teuchos::rcpFromRef(amesos2_params) );
+
+    solver->symbolicFactorization();
+    solver->numericFactorization();
+    solver->solve();
+
+    *fos << "\nA^-1 * B Solution Try2 :" << std::endl;
+    X->describe(*fos,Teuchos::VERB_EXTREME);
+
+
+    solver->setB(BT);
+    amesos2_params.set("Transpose", true, "transpose solve");
+    //amesos2_params.sublist("ShyLUBasker").set("transpose", true, "Transpose solve");
+    solver->setParameters( Teuchos::rcpFromRef(amesos2_params) );
+//    solver->symbolicFactorization();
+//    solver->numericFactorization();
+    solver->solve();
+
+    *fos << "\nAT^-1 * BT Solution Try2 :" << std::endl;
     X->describe(*fos,Teuchos::VERB_EXTREME);
   }
 

--- a/packages/amesos2/src/Amesos2_ShyLUBasker_decl.hpp
+++ b/packages/amesos2/src/Amesos2_ShyLUBasker_decl.hpp
@@ -214,7 +214,10 @@ private:
   "Kokkos node type not support by experimental ShyLUBasker Amesos2");
   */
   typedef Kokkos::OpenMP Exe_Space;
+   // Instance for non-transpose solves
    ::BaskerNS::BaskerTrilinosInterface<local_ordinal_type, slu_type, Exe_Space> *ShyLUbasker;
+   // Instance for transpose solves
+   ::BaskerNS::BaskerTrilinosInterface<local_ordinal_type, slu_type, Exe_Space> *ShyLUbaskerTr;
 #else
   #pragma message("Amesos_ShyLUBasker_decl Error: ENABLED SHYLU_NODEBASKER BUT NOT KOKKOS or NOT OPENMP!")
 #endif


### PR DESCRIPTION
@iyamazaki @hkthorn
Here is PR to Ichi's fork with the temporary Amesos2 changes to allow non-trans and trans solves with ShyLUBasker using the same solver instance.
I tested reverting the commit and it seemed to work fine, but if we run into issues removing this via revert later all the stuff added here has a "Tr" suffix, so it should be pretty easy to cleanup.